### PR TITLE
POST /api/organizer/competition/:competition_id/score csvの参加者存在チェックのN1解消

### DIFF
--- a/go/isuports.go
+++ b/go/isuports.go
@@ -1049,7 +1049,7 @@ func competitionScoreHandler(c echo.Context) error {
 	playerScoreRows := []PlayerScoreRow{}
 	// tenantで絞ってplayerリストをとる
 	dbPlayers := []PlayerRow{}
-	if err := tenantDB.GetContext(ctx, &dbPlayers, "SELECT * FROM player"); err != nil {
+	if err := tenantDB.SelectContext(ctx, &dbPlayers, "SELECT * FROM player WHERE tenant_id = ?", v.tenantID); err != nil {
 		fmt.Errorf("error retrievePlayer: %w", err)
 	}
 


### PR DESCRIPTION
#1 

```
06:00:07.623540 初期化リクエストに成功しました 実装言語:go
06:00:07.623563 整合性チェックを開始します
06:00:08.474311 error: 大会結果CSV入稿 POST /api/organizer/competition/0649f092-c733-41bb-9609-e9a049a6ba6f/score : expected([200]) != actual(400) tenant:i-xsov-1658556007 role:organizer playerID:organizer competitionID:0649f092-c733-41bb-9609-e9a049a6ba6f  CSV length:4074bytes
06:00:08.492486 error: 大会結果CSV入稿 POST /api/organizer/competition/9600f934-4b1e-4c6e-bc3f-c29120345f74/score : expected([200]) != actual(400) tenant:ku-rclt-1658556007 role:organizer playerID:organizer competitionID:9600f934-4b1e-4c6e-bc3f-c29120345f74  CSV length:4156bytes
06:00:08.548417 整合性チェックを終了します
06:00:08.548429 整合性チェックに失敗しました
06:00:09.548608 ERROR[0] prepare: load-validation: POST /api/organizer/competition/0649f092-c733-41bb-9609-e9a049a6ba6f/score : expected([200]) != actual(400) tenant:i-xsov-1658556007 role:organizer playerID:organizer competitionID:0649f092-c733-41bb-9609-e9a049a6ba6f  CSV length:4074bytes
06:00:09.548630 ERROR[1] prepare: load-validation: POST /api/organizer/competition/9600f934-4b1e-4c6e-bc3f-c29120345f74/score : expected([200]) != actual(400) tenant:ku-rclt-1658556007 role:organizer playerID:organizer competitionID:9600f934-4b1e-4c6e-bc3f-c29120345f74  CSV length:4156bytes
06:00:09.548805 Error 2 (Critical:0)
06:00:09.548808 PASSED: false
06:00:09.548811 SCORE: 0 (+0 0(2%))
```

気になる

"POST","uri":"/api/organizer/competition/0000000000/score","user_agent":"isucandar","status":404,"error":"code=404, message=competition not found","latency":604250,"latency_human":"604.25µs","bytes_in":258,"bytes_o>
Jul 23 06:00:08 ip-192-168-0-11 isuports[62327]: {"time":"2022-07-23T06:00:08.522178851Z","level":"ERROR","prefix":"echo","file":"isuports.go","line":"187","message":"error at /api/organizer/competition/:competition_id/score: code=400, message=player not found: 0000000000"}
