### PR TITLE
プレイヤーAPI内でのN+1を軽減

### DIFF
--- a/go/isuports.go
+++ b/go/isuports.go
@@ -1222,8 +1222,9 @@ func playerHandler(c echo.Context) error {
 	if err := tenantDB.SelectContext(
 		ctx,
 		&cs,
-		"SELECT * FROM competition WHERE tenant_id = ? ORDER BY created_at ASC",
+		"SELECT * FROM competition WHERE tenant_id = ? AND id IN (SELECT DISTINCT competition_id FROM player_score WHERE player_id = ?) ORDER BY created_at ASC",
 		v.tenantID,
+		p.ID,
 	); err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("error Select competition: %w", err)
 	}
@@ -1234,7 +1235,7 @@ func playerHandler(c echo.Context) error {
 		return fmt.Errorf("error flockByTenantID: %w", err)
 	}
 	defer fl.Close()
-	pss := make([]PlayerScoreRow, 0, len(cs))
+	var psds []PlayerScoreDetail
 	for _, c := range cs {
 		ps := PlayerScoreRow{}
 		if err := tenantDB.GetContext(
@@ -1252,17 +1253,8 @@ func playerHandler(c echo.Context) error {
 			}
 			return fmt.Errorf("error Select player_score: tenantID=%d, competitionID=%s, playerID=%s, %w", v.tenantID, c.ID, p.ID, err)
 		}
-		pss = append(pss, ps)
-	}
-
-	psds := make([]PlayerScoreDetail, 0, len(pss))
-	for _, ps := range pss {
-		comp, err := retrieveCompetition(ctx, tenantDB, ps.CompetitionID)
-		if err != nil {
-			return fmt.Errorf("error retrieveCompetition: %w", err)
-		}
 		psds = append(psds, PlayerScoreDetail{
-			CompetitionTitle: comp.Title,
+			CompetitionTitle: c.Title,
 			Score:            ps.Score,
 		})
 	}


### PR DESCRIPTION
kataribe内1の `GET /api/player/player/{small-uuid}` に対するN+1軽減

```
Top 20 Sort By Total
Count     Total    Mean  Stddev     Min   P50.0   P90.0   P95.0   P99.0     Max   2xx  3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
 2396  2071.696  0.8646  1.9572   0.001   0.172   2.067   2.557   7.601  30.001  2316    0   80    0     2499397          0       1043       2360  GET /api/player/player/{small-uuid}
```
